### PR TITLE
ADHARA-2227: Remove prefix when signing

### DIFF
--- a/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/internalresponse/EthSignBodyProvider.java
+++ b/ethsigner/core/src/main/java/tech/pegasys/ethsigner/core/requesthandler/internalresponse/EthSignBodyProvider.java
@@ -66,9 +66,7 @@ public class EthSignBodyProvider implements BodyProvider {
       }
       final TransactionSigner signer = transactionSigner.get();
       final String originalMessage = params.get(1);
-      final String message =
-          (char) 25 + "Ethereum Signed Message:\n" + originalMessage.length() + originalMessage;
-      final Signature signature = signer.sign(message.getBytes(StandardCharsets.UTF_8));
+      final Signature signature = signer.sign(originalMessage.getBytes(StandardCharsets.UTF_8));
 
       final Bytes outputSignature =
           Bytes.concatenate(

--- a/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/jsonrpcproxy/EthSignBodyProviderTest.java
+++ b/ethsigner/core/src/test/java/tech/pegasys/ethsigner/core/jsonrpcproxy/EthSignBodyProviderTest.java
@@ -29,6 +29,7 @@ import tech.pegasys.signers.secp256k1.api.TransactionSigner;
 import tech.pegasys.signers.secp256k1.api.TransactionSignerProvider;
 
 import java.math.BigInteger;
+import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -44,6 +45,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.web3j.crypto.ECDSASignature;
 import org.web3j.crypto.ECKeyPair;
+import org.web3j.crypto.Hash;
 import org.web3j.crypto.Sign;
 import org.web3j.utils.Numeric;
 
@@ -137,12 +139,11 @@ public class EthSignBodyProviderTest {
 
     final JsonRpcRequest request = new JsonRpcRequest("2.0", "eth_sign");
     final int id = 1;
+    final String message =
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Tubulum"
+            + " fuisse, qua illum, cuius is condemnatus est rogatione, P. Eaedem res maneant alio modo.";
     request.setId(new JsonRpcRequestId(id));
-    request.setParams(
-        List.of(
-            "address",
-            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Tubulum"
-                + " fuisse, qua illum, cuius is condemnatus est rogatione, P. Eaedem res maneant alio modo."));
+    request.setParams(List.of("address", message));
 
     final JsonRpcBody body = bodyProvider.getBody(request);
     assertThat(body.hasError()).isFalse();
@@ -151,9 +152,7 @@ public class EthSignBodyProviderTest {
     final byte[] signature = Numeric.hexStringToByteArray(hexSignature);
 
     final ECDSASignature expectedSignature =
-        keyPair.sign(
-            Numeric.hexStringToByteArray(
-                "0xe63325d74baa84af003dfb6a974f41672be881b56aa2c12c093f8259321bd460"));
+        keyPair.sign(Hash.sha3(message.getBytes(Charset.defaultCharset())));
     assertThat(new BigInteger(1, signature, 0, 32)).isEqualTo(expectedSignature.r);
     assertThat(new BigInteger(1, signature, 32, 32)).isEqualTo(expectedSignature.s);
   }


### PR DESCRIPTION
We do not use message prefixing in our solutions. It is something that is implemented for personal account signing in go-ethereum and break things on our side.