### PR TITLE
Added multi-dockerfile builds and cloudhsm Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,11 +173,6 @@ jobs:
           name: build image - cloudhsm
           command: |
             ./gradlew --no-daemon distDocker -Pdockerfile=cloudhsm
-      - run:
-          name: test image - cloudhsm
-          command: |
-            mkdir -p docker/reports
-            ./gradlew --no-daemon testDocker -Pdockerfile=cloudhsm
       #- notify
 
   publish:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,16 @@ jobs:
           command: |
             mkdir -p docker/reports
             ./gradlew --no-daemon testDocker
-      - notify            
+      - run:
+          name: build image - cloudhsm
+          command: |
+            ./gradlew --no-daemon distDocker -Pdockerfile=cloudhsm
+      - run:
+          name: test image - cloudhsm
+          command: |
+            mkdir -p docker/reports
+            ./gradlew --no-daemon testDocker -Pdockerfile=cloudhsm
+      - notify
 
   publish:
     executor: executor_med
@@ -195,6 +204,11 @@ jobs:
           command: |
             docker login --username "${DOCKER_USER}" --password "${DOCKER_PASSWORD}"
             ./gradlew --no-daemon --parallel "-Pbranch=${CIRCLE_BRANCH}" dockerUpload
+      - run:
+          name: Publish Docker - cloudhsm
+          command: |
+            docker login --username "${DOCKER_USER}" --password "${DOCKER_PASSWORD}"
+            ./gradlew --no-daemon --parallel "-Pbranch=${CIRCLE_BRANCH}" dockerUpload -Pdockerfile=cloudhsm
       - notify
       
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
           no_output_timeout: 20m
           command: |
             ./gradlew --no-daemon --parallel integrationTest --info
-      - notify      
+      #- notify      
       - capture_test_results
       - capture_test_reports
       - save_cache:
@@ -178,7 +178,7 @@ jobs:
           command: |
             mkdir -p docker/reports
             ./gradlew --no-daemon testDocker -Pdockerfile=cloudhsm
-      - notify
+      #- notify
 
   publish:
     executor: executor_med
@@ -190,7 +190,7 @@ jobs:
           name: Publish
           command: |
             ./gradlew --no-daemon --parallel bintrayUpload
-      - notify
+      #- notify
       
   publishDocker:
     executor: executor_med
@@ -209,7 +209,7 @@ jobs:
           command: |
             docker login --username "${DOCKER_USER}" --password "${DOCKER_PASSWORD}"
             ./gradlew --no-daemon --parallel "-Pbranch=${CIRCLE_BRANCH}" dockerUpload -Pdockerfile=cloudhsm
-      - notify
+      #- notify
       
 workflows:
   version: 2

--- a/build.gradle
+++ b/build.gradle
@@ -486,29 +486,36 @@ tasks.register("dockerDistUntar") {
 }
 
 task distDocker(type: Exec) {
+  def tagSuffix = project.hasProperty("dockerfile")? "-" + dockerfile : ""
+  def dockerfile = project.hasProperty("dockerfile")? dockerfile + ".Dockerfile" : "Dockerfile"
   dependsOn dockerDistUntar
   def dockerBuildVersion = project.hasProperty('release.releaseVersion') ? project.property('release.releaseVersion') : "${rootProject.version}"
   def imageName = dockerRepo + "/" + repositoryName
-  def image = project.hasProperty('release.releaseVersion') ? "${imageName}:" + project.property('release.releaseVersion') : "${imageName}:${project.version}"
+  def image = project.hasProperty('release.releaseVersion') ? "${imageName}:" + project.property('release.releaseVersion')  + "${tagSuffix}": "${imageName}:${project.version}${tagSuffix}"
   def dockerBuildDir = "build/docker-" + repositoryName + "/"
   workingDir "${dockerBuildDir}"
 
   doFirst {
     copy {
-      from file("${projectDir}/docker/Dockerfile")
+      from file("${projectDir}/docker/" + dockerfile)
+      into(workingDir)
+    }
+    copy {
+      from file("${projectDir}/docker/cloudhsm-entrypoint.sh")
       into(workingDir)
     }
   }
 
   executable "sh"
-  args "-c", "docker build --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."
+  args "-c", "docker build -f ${dockerfile} --build-arg BUILD_DATE=${buildTime()} --build-arg VERSION=${dockerBuildVersion} --build-arg VCS_REF=${getCheckedOutGitCommitHash()} -t ${image} ."
 }
 
 task testDocker(type: Exec) {
   dependsOn distDocker
+  def tagSuffix = project.hasProperty("dockerfile")? "-" + dockerfile : ""
   def dockerReportsDir = "docker/reports/"
   def imageName = dockerRepo + "/" + repositoryName
-  def image = project.hasProperty('release.releaseVersion') ? "${imageName}:" + project.property('release.releaseVersion') : "${imageName}:${project.version}"
+  def image = project.hasProperty('release.releaseVersion') ? "${imageName}:" + project.property('release.releaseVersion')  + "${tagSuffix}": "${imageName}:${project.version}${tagSuffix}"
   workingDir "docker"
 
   doFirst {
@@ -521,18 +528,19 @@ task testDocker(type: Exec) {
 
 task dockerUpload(type: Exec) {
   dependsOn distDocker
+  def tagSuffix = project.hasProperty("dockerfile")? "-" + dockerfile : ""
   def imageName = dockerRepo + "/" + repositoryName
-  def image = project.hasProperty('release.releaseVersion') ? "${imageName}:" + project.property('release.releaseVersion') : "${imageName}:${project.version}"
+  def image = project.hasProperty('release.releaseVersion') ? "${imageName}:" + project.property('release.releaseVersion')  + "${tagSuffix}": "${imageName}:${project.version}${tagSuffix}"
   def cmd = "docker push '${image}'"
   def additionalTags = []
 
   if (project.hasProperty('branch') && project.property('branch') == 'master') {
-    additionalTags.add('develop')
+    additionalTags.add("develop${tagSuffix}")
   }
 
   if (!(version ==~ /.*-SNAPSHOT/)) {
-    additionalTags.add('latest')
-    additionalTags.add(version.split(/\./)[0..1].join('.'))
+    additionalTags.add("latest${tagSuffix}")
+    additionalTags.add(version.split(/\./)[0..1].join('.') + "${tagSuffix}")
   }
 
   additionalTags.each { tag -> cmd += " && docker tag '${image}' '${imageName}:${tag.trim()}' && docker push '${imageName}:${tag.trim()}'" }

--- a/docker/cloudhsm-entrypoint.sh
+++ b/docker/cloudhsm-entrypoint.sh
@@ -1,0 +1,33 @@
+#! /bin/bash
+
+# Set HSM IP as an environmental variable
+# ENV HSM_IP <insert the IP address of an active CloudHSM instance here>
+
+if [[ -z "$HSM_IP" ]]; then
+  #statements
+  echo -e "\n* HSM_IP env variable must be set \n"
+  exit 1
+fi
+
+# Configure cloudhms-client
+# COPY customerCA.crt /opt/cloudhsm/etc/
+/opt/cloudhsm/bin/configure -a $HSM_IP
+
+# start cloudhsm client
+echo -n "* Starting CloudHSM client ... "
+/opt/cloudhsm/bin/cloudhsm_client /opt/cloudhsm/etc/cloudhsm_client.cfg &> /tmp/cloudhsm_client_start.log &
+
+# wait for startup
+while true
+do
+    if grep 'libevmulti_init: Ready !' /tmp/cloudhsm_client_start.log &> /dev/null
+    then
+	echo "[OK]"
+	break
+    fi
+    sleep 0.5
+done
+echo -e "\n* CloudHSM client started successfully ... \n"
+
+# start application
+/opt/ethsigner/bin/ethsigner $@

--- a/docker/cloudhsm.Dockerfile
+++ b/docker/cloudhsm.Dockerfile
@@ -9,6 +9,7 @@ RUN yum install -y https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/E
 
 # Install Java, Maven, wget, unzip and ncurses-compat-libs
 RUN yum install -y java wget unzip ncurses-compat-libs
+RUN yum install -y which
 
 COPY cloudhsm-entrypoint.sh /opt/ethsigner/bin/cloudhsm-entrypoint.sh
 RUN chmod +x /opt/ethsigner/bin/cloudhsm-entrypoint.sh

--- a/docker/cloudhsm.Dockerfile
+++ b/docker/cloudhsm.Dockerfile
@@ -1,0 +1,37 @@
+# Use the amazon linux image
+FROM amazonlinux:2
+
+# Install CloudHSM client
+RUN yum install -y https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-latest.el7.x86_64.rpm
+
+# Install CloudHSM Java library
+RUN yum install -y https://s3.amazonaws.com/cloudhsmv2-software/CloudHsmClient/EL7/cloudhsm-client-jce-latest.el7.x86_64.rpm
+
+# Install Java, Maven, wget, unzip and ncurses-compat-libs
+RUN yum install -y java wget unzip ncurses-compat-libs
+
+COPY cloudhsm-entrypoint.sh /opt/ethsigner/bin/cloudhsm-entrypoint.sh
+RUN chmod +x /opt/ethsigner/bin/cloudhsm-entrypoint.sh
+
+COPY ethsigner /opt/ethsigner/
+WORKDIR /opt/ethsigner
+
+# Expose services ports
+# 8545 HTTP JSON-RPC
+EXPOSE 8545
+
+ENTRYPOINT ["/opt/ethsigner/bin/cloudhsm-entrypoint.sh"]
+
+# Build-time metadata as defined at http://label-schema.org
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="Ethsigner" \
+      org.label-schema.description="Ethereum transaction signing application" \
+      org.label-schema.url="https://docs.ethsigner.pegasys.tech/" \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/PegaSysEng/ethsigner.git" \
+      org.label-schema.vendor="Pegasys" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.schema-version="1.0"


### PR DESCRIPTION
How to test locally:

1. build docker image
```
./gradlew clean build distDocker -Pdockerfile=cloudhsm
```

2. Execute the following to start an ethsigner container (change HSM_IP and --slot-pin). Also you will need to get the certificate from cloudhsm

```bash
#!/bin/bash
set -eo pipefail


docker run --rm --name ethsigner \
  -e HSM_IP="10.1.0.171" \
  -v $PWD/ecd7b37cb0d7220eee1c970669b16b635de60196.toml:/etc/ethsigner/keyfiles/ecd7b37cb0d7220eee1c970669b16b635de60196.toml \
  -v $PWD/customerCA.crt:/opt/cloudhsm/etc/customerCA.crt \
  -p 6545:6545 \
  adharaprojects/ethsigner:0.7.0-ADHARA-SNAPSHOT-cloudhsm \
  --chain-id=44844  \
  --downstream-http-host=host.docker.internal  \
  --downstream-http-port=8545 \
  --http-listen-port=6545 \
  --http-listen-host="0.0.0.0" \
  --downstream-http-request-timeout=30000 \
  multikey-signer \
  --directory="/etc/ethsigner/keyfiles/" \
  --library="/opt/cloudhsm/lib/libcloudhsm_pkcs11.so" \
  --slot-label="cavium" \
  --slot-pin="alice:*******"


```
